### PR TITLE
keep list of activated plugins.  only deactivate active plugins on close/deactivation.

### DIFF
--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -54,6 +54,7 @@ class PluginManager(object):
         self.base_class = base_class
         self.factory = factory
         self.load_order = []
+        self.active_plugins = []
         #self.plugin_dir = os.path.realpath(self.config.plugin_path)
         self.plugin_dir = path.child(self.config.plugin_path)
         sys.path.append(self.plugin_dir.path)
@@ -136,12 +137,13 @@ class PluginManager(object):
             if self.config.config['plugin_config'][plugin.name]['auto_activate']:
                 try:
                     plugin.activate()
+                    self.active_plugins.append(plugin.name)
                 except FatalPluginError as e:
                     self.logger.critical("A plugin reported a fatal error. Error: %s", str(e))
                     raise
 
     def deactivate_plugins(self):
-        for plugin in [self.plugins[x] for x in reversed(self.load_order)]:
+        for plugin in [self.plugins[x] for x in self.active_plugins]:
             plugin.deactivate()
 
     def do(self, protocol, command, data):
@@ -187,8 +189,7 @@ class PluginManager(object):
             raise PluginNotFound("No plugin with name=%s found." % name.lower())
 
     def die(self):
-        for plugin in self.plugins.itervalues():
-            plugin.deactivate()
+        self.deactivate_plugins()
 
 
 def route(func):


### PR DESCRIPTION
Was getting an error on exit from web_gui, which I imported from an old version folder, but I didn't have it activated (auto_activate: false).

This changes the deactivate() method of plugin_manager to only care about plugins that have been activated.

This does make the plugin_manager no longer check the 'load_order' during deactivation, but this doesn't currently effect anything (kinda messy though I know).

I had the idea to make this cleaner by refactoring the plugin_manager to only load plugins that we want (rather than all plugins in plugin_dir), but that is going to take a bit longer.

I can understand if you don't like this change as the motivation could be seen as a bug in the web_gui plugin, but people who are trying to use StarryPy could end up copying their plugins folders between versions and get strange errors from plugins they don't use (like I did).